### PR TITLE
Lecturer delete consultations

### DIFF
--- a/__tests__/studentTests.spec.js
+++ b/__tests__/studentTests.spec.js
@@ -24,7 +24,7 @@ describe('getAllEvents', () => {
     // Assertions
     expect(require('../db_connection').promise).toHaveBeenCalledTimes(1)
     expect(mockQuery).toHaveBeenCalledTimes(1)
-    expect(mockQuery).toHaveBeenCalledWith(`SELECT p.Name AS PersonName, e.RecurringWeeks AS NumberOfWeeks, e.Description AS EventDescription, e.StartTime AS EventStartTime, e.StartDate AS EventDate, e.Duration AS EventDuration, e.SlotsPerDay, e.Id AS EventId, COALESCE(eb.EventBookingCount, 0) AS EventBookingCount
+    expect(mockQuery).toHaveBeenCalledWith(`SELECT p.Name AS PersonName, e.RecurringWeeks AS NumberOfWeeks, e.Description AS EventDescription, e.StartTime AS EventStartTime,  DATE_FORMAT(e.StartDate,'%Y-%m-%d') AS EventDate, e.Duration AS EventDuration, e.SlotsPerDay, e.Id AS EventId, COALESCE(eb.EventBookingCount, 0) AS EventBookingCount
                                               FROM event e
                                               JOIN person p ON e.PersonId = p.Id
                                               LEFT JOIN(
@@ -47,7 +47,7 @@ describe('getAllEvents', () => {
     // Assertions
     expect(require('../db_connection').promise).toHaveBeenCalledTimes(1)
     expect(mockQuery).toHaveBeenCalledTimes(1)
-    expect(mockQuery).toHaveBeenCalledWith(`SELECT p.Name AS PersonName, e.RecurringWeeks AS NumberOfWeeks, e.Description AS EventDescription, e.StartTime AS EventStartTime, e.StartDate AS EventDate, e.Duration AS EventDuration, e.SlotsPerDay, e.Id AS EventId, COALESCE(eb.EventBookingCount, 0) AS EventBookingCount
+    expect(mockQuery).toHaveBeenCalledWith(`SELECT p.Name AS PersonName, e.RecurringWeeks AS NumberOfWeeks, e.Description AS EventDescription, e.StartTime AS EventStartTime,  DATE_FORMAT(e.StartDate,'%Y-%m-%d') AS EventDate, e.Duration AS EventDuration, e.SlotsPerDay, e.Id AS EventId, COALESCE(eb.EventBookingCount, 0) AS EventBookingCount
                                               FROM event e
                                               JOIN person p ON e.PersonId = p.Id
                                               LEFT JOIN(
@@ -129,7 +129,7 @@ describe('getAllConsults', () => {
     expect(require('../db_connection').promise).toHaveBeenCalledTimes(1)
     expect(mockQuery).toHaveBeenCalledTimes(1)
     expect(mockQuery).toHaveBeenCalledWith(
-      'SELECT e.StartTime, e.Duration, e.StartDate, e.Description, eb.eventId, eb.Id AS bookingId, p.name AS lecturerName FROM event_booking eb JOIN event e ON eb.EventId = e.Id JOIN person p ON p.Id = e.PersonId WHERE eb.personId = ?',
+      "SELECT e.StartTime, e.Duration, DATE_FORMAT(eb.Date,'%Y-%m-%d') StartDate, e.Description, eb.eventId, eb.Id AS bookingId, p.name AS lecturerName FROM event_booking eb JOIN event e ON eb.EventId = e.Id JOIN person p ON p.Id = e.PersonId WHERE eb.personId = ?",
       [personId]
     )
     expect(consults).toEqual(mockConsults[0])
@@ -148,7 +148,7 @@ describe('getAllConsults', () => {
     // Assertions
     expect(mockQuery).toHaveBeenCalledTimes(1)
     expect(mockQuery).toHaveBeenCalledWith(
-      'SELECT e.StartTime, e.Duration, e.StartDate, e.Description, eb.eventId, eb.Id AS bookingId, p.name AS lecturerName FROM event_booking eb JOIN event e ON eb.EventId = e.Id JOIN person p ON p.Id = e.PersonId WHERE eb.personId = ?',
+      "SELECT e.StartTime, e.Duration, DATE_FORMAT(eb.Date,'%Y-%m-%d') StartDate, e.Description, eb.eventId, eb.Id AS bookingId, p.name AS lecturerName FROM event_booking eb JOIN event e ON eb.EventId = e.Id JOIN person p ON p.Id = e.PersonId WHERE eb.personId = ?",
       [personId]
     )
   })

--- a/mainRoutes.js
+++ b/mainRoutes.js
@@ -226,6 +226,15 @@ mainRouter.get('/lecturerUpcomingConsultations', authMiddleware('teacher'), asyn
   res.send(results)
 })
 
+//Route to get all lecturer consultations
+mainRouter.get('/lecturerAllConsultations', authMiddleware('teacher'), async function (req, res) {
+  userID = req.cookies.userID
+  res.type('application/json')
+
+  const results = await lecUpcomingConsults.allConsultations(userID)
+  res.send(results)
+})
+
 mainRouter.post('/lecDeleteBooking', authMiddleware('teacher'), async function (req, res) {
   res.type('application/json')
   const bookingID = req.body.bookingID
@@ -234,6 +243,19 @@ mainRouter.post('/lecDeleteBooking', authMiddleware('teacher'), async function (
   // Log the action
   const timestamp = new Date().toISOString().slice(0, 19).replace('T', ' ');
   const params = [req.cookies.userID, "Lecturer deleted a booking", timestamp];
+  await conn.promise().query("INSERT INTO log (PersonId, Action, TimeStamp) VALUES (?, ?, ?)", params);
+
+  res.send(result)
+})
+
+mainRouter.post('/lecDeleteEvent', authMiddleware('teacher'), async function (req, res) {
+  res.type('application/json')
+  const bookingID = req.body.bookingID
+  const result = await lecDeleteUpcomingBooking.lecDeleteEvent(bookingID)
+
+  // Log the action
+  const timestamp = new Date().toISOString().slice(0, 19).replace('T', ' ');
+  const params = [req.cookies.userID, "Lecturer deleted an event", timestamp];
   await conn.promise().query("INSERT INTO log (PersonId, Action, TimeStamp) VALUES (?, ?, ?)", params);
 
   res.send(result)

--- a/mainRoutes.js
+++ b/mainRoutes.js
@@ -62,7 +62,7 @@ mainRouter.post('/login', async function (req, res) {
     // Set the JWT in an HttpOnly cookie
     res.cookie('token', token, { httpOnly: true })
 
-    res.cookie('userID', result.userID)
+    //res.cookie('userID', result.userID)
   }
 
   res.send(result)

--- a/mainRoutes.js
+++ b/mainRoutes.js
@@ -280,7 +280,7 @@ mainRouter.get('/logout', async function (req, res) {
 mainRouter.get('/logData', async function (req, res) {
   try {
     const [rows, fields] = await conn.promise().query(
-      `SELECT p.Name, p.Role, l.Action, l.TimeStamp 
+      `SELECT p.Name, p.Role, l.Action, DATE_FORMAT(l.TimeStamp,'%Y-%m-%d %T') TimeStamp 
        FROM log l
        INNER JOIN person p ON l.PersonId = p.Id
        ORDER BY l.TimeStamp DESC`

--- a/public/c_admin.js
+++ b/public/c_admin.js
@@ -25,9 +25,9 @@ window.addEventListener('DOMContentLoaded', (event) => {
                 const timestampElement = document.createElement('span');
                 const dateTime = logEntry.TimeStamp.replace('T', ' ').replace('Z', '');
                 const dateObj = new Date(dateTime);
-                dateObj.setHours(dateObj.getHours() + 2); // Convert to South African time (GMT+2)
-                const formattedDateTime = dateObj.toLocaleString('en-ZA'); // Format date and time to South African locale
-                timestampElement.innerHTML = `<span class="timestamp">Date and Time:</span> <span class="value">${formattedDateTime}</span>`;
+                //dateObj.setHours(dateObj.getHours() + 2); // Convert to South African time (GMT+2)
+                //const formattedDateTime = dateObj.toLocaleString('en-ZA'); // Format date and time to South African locale
+                timestampElement.innerHTML = `<span class="timestamp">Date and Time (UTC):</span> <span class="value">${logEntry.TimeStamp}</span>`;
                 div.appendChild(timestampElement);
 
                 logDataDiv.appendChild(div);

--- a/public/c_captureFields.js
+++ b/public/c_captureFields.js
@@ -130,8 +130,11 @@ function previewConsultation() {
 
   const startTime = document.getElementById('start-time').value
   const endTime = document.getElementById('end-time').value
+  
+  const startTicks = new Date(startDate.toISOString().substring(0, 10) + ' ' + startTime).getTime()
+  const endTicks = new Date(startDate.toISOString().substring(0, 10) + ' ' + endTime).getTime()
 
-  // Check end time is valid:
+    // Check end time is valid:
   if (new Date('1970/01/01 ' + endTime) < new Date('1970/01/01 ' + startTime)) {
     alert('Cannot end a consultation before it starts. \nPlease reselect end time')
     return
@@ -140,6 +143,9 @@ function previewConsultation() {
 
     return
   }
+
+ 
+  
 
   const maxConsultStudents = document.getElementById('max-consults-students').value
   let recurringWeeks = document.getElementById('num-weeks-recurring').value
@@ -173,9 +179,37 @@ function previewConsultation() {
   if (description != '') {
     consultationSummaryString += '<br />' + 'Description: ' + description
   }
-
-  $('#consultationSummary').modal('show')
+  
   document.getElementById('consultationSummaryModalBody').innerHTML = (consultationSummaryString)
+
+   //Check consultation doesn't overlap with existing consultations
+   $.ajax({
+    type: 'GET',
+    contentType: 'application/json',
+    url: './lecturerAllConsultations' // URL that the POST is sent to
+  }).done(function (res) {
+    let conflict = false;
+    for (let i = 0; i < res.length; i++)
+    {
+      const eStartTicks = new Date (res[i].StartDate + ' ' + res[i].StartTime).getTime()
+      const eEndTicks = new Date (res[i].EndDate + ' ' + res[i].EndTime).getTime()
+      if((eStartTicks <= endTicks) && (eEndTicks >= startTicks))
+      {
+        
+        alert(`Cannot create consultation - consultation: ${res[i].Description} has a conflicting time`)
+        conflict = true
+        return
+      }
+    }
+    if(!conflict)
+    {
+      $('#consultationSummary').modal('show')
+      return
+    }
+  })
+
+  
+  
 
   // get day of week to store in database
   const dow = startDate.toString().substring(0, 3)

--- a/public/c_captureFields.js
+++ b/public/c_captureFields.js
@@ -1,5 +1,5 @@
 
-function loadConsultations() {
+function loadBookings() {
   $.ajax({
     type: 'GET',
     contentType: 'application/json',
@@ -9,7 +9,7 @@ function loadConsultations() {
   })
 }
 
-loadConsultations()
+loadBookings()
 
 // populate upcoming consultations section
 function populateUpcoming(consultations) {
@@ -17,13 +17,13 @@ function populateUpcoming(consultations) {
   for (let i = 0; i < consultations.length; i++) {
     content.push(createUpcomingEntry(consultations[i]))
   }
-  $('#upcomingConsultationsList').html(content.join(''))
+  $('#upcomingBookingsList').html(content.join(''))
 }
 
 function createUpcomingEntry(consultation) {
   const content = []
   const consultationDate = new Date(consultation.Date) // Convert the consultation date to a Date object
-  consultationDate.setDate(consultationDate.getDate() + 1) // Set the consultation date to match with student dashboard
+  //consultationDate.setDate(consultationDate.getDate() + 1) // Set the consultation date to match with student dashboard
 
   content.push('<li class="list-group-item">')
   content.push('<div class="row">')
@@ -31,12 +31,12 @@ function createUpcomingEntry(consultation) {
   content.push(`<div class="col-md-3">${consultation.Description}</div>`)
   content.push(`<div class="col-md-3">${consultationDate.toISOString().split('T')[0]} @ ${consultation.StartTime}</div>`)
   content.push(`<div class="col-md-2">${consultation.Duration} mins</div>`)
-  content.push(`<div class="col-md-2"><button class="btn btn-danger" onclick="deleteConsultation(${consultation.Id})">Delete</button></div>`)
+  content.push(`<div class="col-md-2"><button class="btn btn-danger" onclick="deleteBooking(${consultation.Id})">Delete</button></div>`)
   content.push('</div></li>')
   return content.join('')
 }
 
-function deleteConsultation(id) {
+function deleteBooking(id) {
   $.ajax({
     type: 'POST',
     contentType: 'application/json',
@@ -45,10 +45,64 @@ function deleteConsultation(id) {
   }).done(function (res) {
     if (res.status === 'Completed') {
       alert(`Booking: "${id}" has been deleted`)
-      loadConsultations()
+      loadBookings()
     }
   })
 }
+
+//Code to fetch and show all of the consultations the lecturer has created:
+
+function loadConsultations() {
+  $.ajax({
+    type: 'GET',
+    contentType: 'application/json',
+    url: './lecturerAllConsultations' // URL that the POST is sent to
+  }).done(function (res) {
+    console.log(res)
+    populateUpcomingConsultations(res)
+  })
+}
+
+loadConsultations()
+
+function populateUpcomingConsultations(consultations) {
+  const content = []
+  for (let i = 0; i < consultations.length; i++) {
+    content.push(createConsulationEntry(consultations[i]))
+  }
+  $('#allConsultationsList').html(content.join(''))
+}
+
+function createConsulationEntry(event) {
+  const content = []
+  
+  const eventDate = new Date(event.StartDate)
+  
+  content.push('<li class="list-group-item">')
+  content.push('<div class="row">')
+  content.push(`<div class="col-md-3 font-weight-bold">${event.Description}</div>`)
+  content.push(`<div class="col-md-2 font-weight-bold">${event.SlotsPerDay}</div>`)
+  content.push(`<div class="col-md-3">${eventDate.toISOString().split('T')[0]} @ ${event.StartTime}</div>`)
+  content.push(`<div class="col-md-2">${event.Duration} mins</div>`)
+  content.push(`<div class="col-md-2"><button class="btn btn-danger" onclick="deleteEvent(${event.Id})">Delete</button></div>`)
+  content.push('</div></li>')
+  return content.join('')
+}
+
+function deleteEvent(id) {
+  $.ajax({
+    type: 'POST',
+    contentType: 'application/json',
+    data: JSON.stringify({ bookingID: id }),
+    url: './lecDeleteEvent' // URL that the POST is sent to
+  }).done(function (res) {
+    if (res.status === 'Completed') {
+      alert(`Consultation: "${id}" has been deleted`)
+      loadBookings()
+    }
+  })
+}
+
 
 document.getElementById('save-chages').addEventListener('click', previewConsultation)
 let createConsultation = null
@@ -155,6 +209,7 @@ function previewConsultation() {
       })
     }
 
+    loadConsultations()
     alert(`Consultation: ${description} created!`)
   }
 

--- a/public/c_student_portal_page.js
+++ b/public/c_student_portal_page.js
@@ -29,7 +29,7 @@ for (let day = 1; day <= 31; day++) {
 // Function to handle event booking
 async function bookEvent(EventId, EventDate) {
   const date = new Date(EventDate)
-  date.setDate(date.getDate() + 1)
+  //date.setDate(date.getDate() + 1)
   const formattedDate = date.toISOString().split('T')[0]
   // console.log(formattedDate)
 
@@ -311,11 +311,10 @@ function processConsults(res) {
   for (let i = 0; i < res.length; i++) {
     // Process each consultation
     const startDate = res[i].StartDate
-    const actualDate = startDate.substr(0, startDate.indexOf('T'))
+    const actualDate = startDate
 
     const consultationDate = new Date(actualDate) // Convert the actualDate to a Date object
-    consultationDate.setDate(consultationDate.getDate() + 1) // Set the consultationDate to be one day ahead as per booked event
-
+    
     let daysUntilConsultation = Math.ceil((consultationDate - currentDate) / (1000 * 60 * 60 * 24)) // Calculate the number of days until the consultation
     if (daysUntilConsultation === 0) {
       daysUntilConsultation = 'Your consultation is today. Please be on time.'

--- a/public/lecturer_dashboard.html
+++ b/public/lecturer_dashboard.html
@@ -33,112 +33,153 @@
         </div>
         <div style="position: relative;">
             <h1 class="text-center my-5">Lecturer Dashboard</h1>
-            <button onclick="location.href='/logout'" style="position: absolute; top: 20%; right: 0;" class="btn btn-secondary">Logout</button>
+            <button onclick="location.href='/logout'" style="position: absolute; top: 20%; right: 0;"
+                class="btn btn-secondary">Logout</button>
         </div>
-        
-        
-            <div class="card mb-3">
-                <div class="card-header"><strong>Upcoming Consultations</strong></div>
+
+        <ul class="nav nav-tabs">
+            <li class="nav-item">
+                <a class="nav-link active" id="tab-upcoming-bookings" data-toggle="tab" href="#upcoming-bookings"
+                    role="tab" aria-controls="upcoming-bookings" aria-selected="true">
+                    Upcoming Bookings
+                </a>
+            </li>
+
+            <li class="nav-item">
+                <a class="nav-link" id="tab-consultations" data-toggle="tab" href="#consultations" role="tab"
+                    aria-controls="consultations" aria-selected="false">
+                    All Consultations
+                </a>
+            </li>
+
+        </ul>
+        <div class="tab-content card mb-3" id="tab-content">
+            <div class="tab-pane fade show active" id="upcoming-bookings" role="tabpanel"
+                aria-labelledby="tab-upcoming-bookings">
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item">
                         <div class="row">
-                            <div class="col-md-2 font-weight-bold">Student Name/s</div>
+                            <div class="col-md-2 font-weight-bold">Student Name</div>
                             <div class="col-md-3 font-weight-bold">Description</div>
                             <div class="col-md-3 font-weight-bold">Date & Time</div>
                             <div class="col-md-2 font-weight-bold">Duration</div>
                             <div class="col-md-2 font-weight-bold">Delete</div>
                         </div>
                     </li>
-                     <span id="upcomingConsultationsList"></span>
+                    <div class="overflow-auto" style="max-height: 400px;">
+                        <span id="upcomingBookingsList"></span>
+                    </div>
                 </ul>
             </div>
-        
-        
-            <div class="card mb-3">
-                <div class="card-header"><strong>Create a Consulation</strong></div>
-                <div class="card-body">
-                    <form id="availability-form">
 
-                        <div class="form-group" id="startDate">
-                            <label for="day-of-month">Consultation date:</label>
-                            <input type="date" class="form-control" id="day-of-month" name="day-of-month">
+            <div class="tab-pane fade" id="consultations" role="tabpanel" aria-labelledby="tab-consultations">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">
+                        <div class="row">
+                            <div class="col-md-3 font-weight-bold">Consultation Desc.</div>
+                            <div class="col-md-2 font-weight-bold">Slots</div>
+                            <div class="col-md-3 font-weight-bold">Date & Time</div>
+                            <div class="col-md-2 font-weight-bold">Duration</div>
+                            <div class="col-md-2 font-weight-bold">Delete</div>
                         </div>
-                        <div class="form-group">
-
-                            <div class="form-group">
-                                <label for="start-time">Start time:</label>
-                                <input type="time" class="form-control" id="start-time" name="start-time">
-                            </div>
-                            <div class="form-group">
-                                <label for="end-time">End time:</label>
-                                <input type="time" class="form-control" id="end-time" name="end-time">
-                            </div>
-
-                            <div class="form-group">
-                                <label for="max-students">Maximum students for this consultation:</label>
-                                <input type="number" placeholder="--" class="form-control" id="max-consults-students"
-                                    name="max-consults-students" min="1">
-                            </div>
-
-                            <!--Recurring radio btn-->
-                            <label for="recurring">Do you want this consultation to be recurring?</label>
-                            <div class="form-check">
-                                <input class="form-check-input" type="radio" name="recurring" id="recurring-yes"
-                                    value="yes">
-                                <label class="form-check-label" for="recurring-yes">Yes</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="radio" name="recurring" id="recurring-no"
-                                    value="no">
-                                <label class="form-check-label" for="recurring-no">No</label>
-                            </div>
-
-                        </div>
-
-                        <div class="form-group" id='weeks-recurring'>
-                            <label for="num-weeks-recur">Number of weeks to recur for (including current week):</label>
-                            <input type="number" placeholder="--" class="form-control" id="num-weeks-recurring"
-                                name="num-weeks-recurring" min="1">
-                        </div>
-                </div>
-
-                <div class="form-check">
-                    <div class="form-group">
-                        <label for="description">Please write any special info about this consultation:</label>
-                        <input type="string" class="form-control" id="description" name="description">
+                    </li>
+                    <div class="overflow-auto" style="max-height: 400px;">
+                        <span id="allConsultationsList"></span>
                     </div>
-                    <button type="button" id="save-chages" class="btn btn-primary">Preview Consultation...</button>
-                    </form>
-                </div>
-
-               
-
-                <!-- Modal -->
-                <div class="modal fade" id="consultationSummary" tabindex="-1" role="dialog"
-                    aria-labelledby="consultationSummaryModalLabel" aria-hidden="true">
-                    <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="exampleModalLabel">Consultation Summary</h5>
-                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span>
-                                </button>
-                            </div>
-                            <div class="modal-body" id="consultationSummaryModalBody">
-                                ...
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
-                                <button type="button" id="create-consultation" class="btn btn-primary">Create Consulation</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                
-
+                </ul>
             </div>
+            
+        </div>
+
         
+
+    </div>
+
+
+    <div class="card mb-3">
+        <div class="card-header"><strong>Create a Consultation</strong></div>
+        <div class="card-body">
+            <form id="availability-form">
+
+                <div class="form-group" id="startDate">
+                    <label for="day-of-month">Consultation date:</label>
+                    <input type="date" class="form-control" id="day-of-month" name="day-of-month">
+                </div>
+                <div class="form-group">
+
+                    <div class="form-group">
+                        <label for="start-time">Start time:</label>
+                        <input type="time" class="form-control" id="start-time" name="start-time">
+                    </div>
+                    <div class="form-group">
+                        <label for="end-time">End time:</label>
+                        <input type="time" class="form-control" id="end-time" name="end-time">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="max-students">Maximum students for this consultation:</label>
+                        <input type="number" placeholder="--" class="form-control" id="max-consults-students"
+                            name="max-consults-students" min="1">
+                    </div>
+
+                    <!--Recurring radio btn-->
+                    <label for="recurring">Do you want this consultation to be recurring?</label>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="recurring" id="recurring-yes" value="yes">
+                        <label class="form-check-label" for="recurring-yes">Yes</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="recurring" id="recurring-no" value="no">
+                        <label class="form-check-label" for="recurring-no">No</label>
+                    </div>
+
+                </div>
+
+                <div class="form-group" id='weeks-recurring'>
+                    <label for="num-weeks-recur">Number of weeks to recur for (including current week):</label>
+                    <input type="number" placeholder="--" class="form-control" id="num-weeks-recurring"
+                        name="num-weeks-recurring" min="1">
+                </div>
+        </div>
+
+        <div class="form-check">
+            <div class="form-group">
+                <label for="description">Please write any special info about this consultation:</label>
+                <input type="string" class="form-control" id="description" name="description">
+            </div>
+            <button type="button" id="save-chages" class="btn btn-primary">Preview Consultation...</button>
+            </form>
+        </div>
+
+
+
+        <!-- Modal -->
+        <div class="modal fade" id="consultationSummary" tabindex="-1" role="dialog"
+            aria-labelledby="consultationSummaryModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Consultation Summary</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body" id="consultationSummaryModalBody">
+                        ...
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+                        <button type="button" id="create-consultation" class="btn btn-primary">Create
+                            Consulation</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+
+    </div>
+
     </div>
     <footer class="text-center mt-5">
         <p>&copy; Consulta</p>

--- a/s_lecDeleteBooking.js
+++ b/s_lecDeleteBooking.js
@@ -11,4 +11,15 @@ async function lecDeleteBooking(bookingID) {
     }
 }
 
-module.exports = { lecDeleteBooking }
+async function lecDeleteEvent(eventID) {
+    try {
+        const result = await conn.promise().query('DELETE FROM event WHERE Id = ?', [eventID])
+        // console.log(result)
+        return { status: 'Completed' }
+    } catch (error) {
+        console.error('Error retrieving events:', error)
+        throw error
+    }
+}
+
+module.exports = { lecDeleteBooking, lecDeleteEvent }

--- a/s_lecturerUpcomingConsultations.js
+++ b/s_lecturerUpcomingConsultations.js
@@ -4,12 +4,29 @@ async function findLecturerUpcomingConsultations(personId)
 {
     try {
         // Use prepared statements to sanitize inputs to protect from SQL injection attacks
-        const [results] = await conn.promise().query("SELECT eb.*, e.StartTime, e.Duration, e.Description, p.name studentName FROM event e JOIN event_booking eb on eb.eventId = e.Id JOIN person p ON p.Id = eb.personId WHERE e.PersonId = ?", [personId])
-        
+        //Strip the time component out of the dates to avoid time-zone 
+        //related date changes due to differences between node server local time and
+        //database server time zone
+        const [results] = await conn.promise().query("SELECT eb.Id, eb.eventId, eb.personId,DATE_FORMAT(Date,'%Y-%m-%d') Date, e.StartTime, e.Duration, e.Description, p.name studentName FROM event e JOIN event_booking eb on eb.eventId = e.Id JOIN person p ON p.Id = eb.personId WHERE e.PersonId = ?", [personId])
+        console.log(results)
         return results
     } catch (error) {
         console.log(error)
     }
 }
 
-module.exports = {findLecturerUpcomingConsultations}
+async function allConsultations(personId)
+{
+    try {
+        //Strip the time component out of the dates to avoid time-zone 
+        //related date changes due to differences between node server local time and
+        //database server time zone
+        const [results] = await conn.promise().query("SELECT e.Id, e.PersonId, e.DOW, DATE_FORMAT(StartDate,'%Y-%m-%d') StartDate,DATE_FORMAT(EndDate,'%Y-%m-%d') EndDate, StartTime, EndTime, Duration, SlotsPerDay, Description  FROM event e WHERE PersonId = ?", [personId])
+        //console.log(results)
+        return results
+    } catch (error) {
+        console.log(error)
+    }
+}
+
+module.exports = {findLecturerUpcomingConsultations, allConsultations}

--- a/s_student_page.js
+++ b/s_student_page.js
@@ -32,7 +32,7 @@ function isValidDate(dateString) {
 // Function to retrieve all events from the database
 async function getAllEvents() {
   try {
-    const events = await pool.promise().query(`SELECT p.Name AS PersonName, e.RecurringWeeks AS NumberOfWeeks, e.Description AS EventDescription, e.StartTime AS EventStartTime, e.StartDate AS EventDate, e.Duration AS EventDuration, e.SlotsPerDay, e.Id AS EventId, COALESCE(eb.EventBookingCount, 0) AS EventBookingCount
+    const events = await pool.promise().query(`SELECT p.Name AS PersonName, e.RecurringWeeks AS NumberOfWeeks, e.Description AS EventDescription, e.StartTime AS EventStartTime,  DATE_FORMAT(e.StartDate,'%Y-%m-%d') AS EventDate, e.Duration AS EventDuration, e.SlotsPerDay, e.Id AS EventId, COALESCE(eb.EventBookingCount, 0) AS EventBookingCount
                                               FROM event e
                                               JOIN person p ON e.PersonId = p.Id
                                               LEFT JOIN(
@@ -51,7 +51,7 @@ async function getAllEvents() {
 async function getAllConsults(personId) {
   try {
     // Use prepared statements to sanitize inputs to protect from SQL injection attacks
-    const query = 'SELECT e.StartTime, e.Duration, e.StartDate, e.Description, eb.eventId, eb.Id AS bookingId, p.name AS lecturerName FROM event_booking eb JOIN event e ON eb.EventId = e.Id JOIN person p ON p.Id = e.PersonId WHERE eb.personId = ?'
+    const query = "SELECT e.StartTime, e.Duration, DATE_FORMAT(eb.Date,'%Y-%m-%d') StartDate, e.Description, eb.eventId, eb.Id AS bookingId, p.name AS lecturerName FROM event_booking eb JOIN event e ON eb.EventId = e.Id JOIN person p ON p.Id = e.PersonId WHERE eb.personId = ?"
     const [results] = await pool.promise().query(query, [personId])
     // console.log(results)
     return results


### PR DESCRIPTION
Lecturer is now able to view and delete any and all of their consultation events, regardless of if it has been booked or not.
Implemented restriction to stop new overlapping consultations from being created.
Date and time discrepancies between database and webpage fixed.
Updated admin logs to show UTC time correctly.
Updated studentTests to deal with new date query format.

All tests pass as of most recent commit in this branch.

This pull request should close #73 